### PR TITLE
Resolves #6 動画の先頭からカットするとpart1のファイルが作られなくてエラーになるのを修正

### DIFF
--- a/domain/cutMarker.py
+++ b/domain/cutMarker.py
@@ -1,5 +1,6 @@
 """
 Cut markers are used to determine the cut points of a video.
+CutMarker has start and end points, and they are expressed as a position string like "00:00:00.000".
 """
 
 
@@ -8,3 +9,5 @@ class CutMarker:
         self.startPoint = startPoint
         self.endPoint = endPoint
 
+    def pointsFileTop(self):
+        return self.startPoint == "00:00:00.000"

--- a/domain/ffmpegCommand.py
+++ b/domain/ffmpegCommand.py
@@ -87,7 +87,7 @@ def cutVideoCommand(task):
         raise ValueError("cutMarkers must not be empty")
     # end if
     cuts = []
-    if not cutMarkers[0].pointsFileTop:
+    if not cutMarkers[0].pointsFileTop():
         cuts.append((millisecondsToPositionStr(0), cutMarkers[0].startPoint))
     # end if
     for i in range(len(cutMarkers) - 1):

--- a/domain/ffmpegCommand.py
+++ b/domain/ffmpegCommand.py
@@ -87,7 +87,9 @@ def cutVideoCommand(task):
         raise ValueError("cutMarkers must not be empty")
     # end if
     cuts = []
-    cuts.append((millisecondsToPositionStr(0), cutMarkers[0].startPoint))
+    if not cutMarkers[0].pointsFileTop:
+        cuts.append((millisecondsToPositionStr(0), cutMarkers[0].startPoint))
+    # end if
     for i in range(len(cutMarkers) - 1):
         cuts.append((cutMarkers[i].endPoint, cutMarkers[i + 1].startPoint))
     # end for

--- a/test/domain_test/testFfmpegCommand.py
+++ b/test/domain_test/testFfmpegCommand.py
@@ -31,3 +31,18 @@ class TestFfmpegCommand(unittest.TestCase):
         self.assertEqual(cmd, "ffmpeg -y -i test.mp4 -ss 00:00:00.000 -to 00:00:01.000 -c copy %s" % os.path.join(concatDir, "test_part1.mp4"))
         cmd = " ".join(set.nthCommand(2).command)
         self.assertEqual(cmd, "ffmpeg -y -i test.mp4 -ss 00:00:02.000 -c copy %s" % os.path.join(concatDir, "test_part2.mp4"))
+
+    def test_cutVideoCommand_cuttingFromTop(self):
+        task = domain.CutVideoTask()
+        task.nthStep(1)._value = "test.mp4"
+        task.nthStep(2)._value = [
+            domain.CutMarker("00:00:00.000", "00:00:02.000"),
+        ]
+        task.nthStep(3)._value = "test2.mp4"
+        chain = domain.cutVideoCommand(task)
+        self.assertEqual(chain.countCommandSets(), 2)
+        concatDir = os.path.join(os.getcwd(), "temp", "concats")
+        set = chain.nthCommandSet(1)
+        self.assertEqual(set.countCommands(), 1)
+        cmd = " ".join(set.nthCommand(1).command)
+        self.assertEqual(cmd, "ffmpeg -y -i test.mp4 -ss 00:00:02.000 -c copy %s" % os.path.join(concatDir, "test_part1.mp4"))


### PR DESCRIPTION
ファイルの開始地点から最初のマーカーの開始位置までを採用しようとしていた。
でも、最初のマーカーがファイルの先頭を指していると、最初から最初という謎コマンドを生成してしまって出力に失敗していた。
最初のマーカーがファイルの先頭を指していたらスキップするように下。