### PR TITLE
ビデオカット編集で、複数のストリームがあるときに最初の1つずつしか採用されなかったのを修正

### DIFF
--- a/domain/ffmpegCommand.py
+++ b/domain/ffmpegCommand.py
@@ -118,6 +118,8 @@ def cutVideoCommand(task):
                 "0",
                 "-i",
                 os.path.join(tempdirRoot(), "concats", "%s_parts.txt" % withoutExtension),
+                "-map",
+                "0",
                 "-c",
                 "copy",
                 task.nthStep(3).getValue()
@@ -141,6 +143,8 @@ def makeCutCommand(input, start, end, part):
     withoutExtension = os.path.basename(input).split(".")[0]
     extension = os.path.basename(input).split(".")[1]
     cmd.extend([
+        "-map",
+        "0",
         "-c",
         "copy",
         os.path.join(root, "concats", "%s_part%d.%s" % (withoutExtension, part, extension))

--- a/test/domain_test/testFfmpegCommand.py
+++ b/test/domain_test/testFfmpegCommand.py
@@ -28,9 +28,9 @@ class TestFfmpegCommand(unittest.TestCase):
         set = chain.nthCommandSet(1)
         self.assertEqual(set.countCommands(), 2)
         cmd = " ".join(set.nthCommand(1).command)
-        self.assertEqual(cmd, "ffmpeg -y -i test.mp4 -ss 00:00:00.000 -to 00:00:01.000 -c copy %s" % os.path.join(concatDir, "test_part1.mp4"))
+        self.assertEqual(cmd, "ffmpeg -y -i test.mp4 -ss 00:00:00.000 -to 00:00:01.000 -map 0 -c copy %s" % os.path.join(concatDir, "test_part1.mp4"))
         cmd = " ".join(set.nthCommand(2).command)
-        self.assertEqual(cmd, "ffmpeg -y -i test.mp4 -ss 00:00:02.000 -c copy %s" % os.path.join(concatDir, "test_part2.mp4"))
+        self.assertEqual(cmd, "ffmpeg -y -i test.mp4 -ss 00:00:02.000 -map 0 -c copy %s" % os.path.join(concatDir, "test_part2.mp4"))
 
     def test_cutVideoCommand_cuttingFromTop(self):
         task = domain.CutVideoTask()
@@ -45,4 +45,4 @@ class TestFfmpegCommand(unittest.TestCase):
         set = chain.nthCommandSet(1)
         self.assertEqual(set.countCommands(), 1)
         cmd = " ".join(set.nthCommand(1).command)
-        self.assertEqual(cmd, "ffmpeg -y -i test.mp4 -ss 00:00:02.000 -c copy %s" % os.path.join(concatDir, "test_part1.mp4"))
+        self.assertEqual(cmd, "ffmpeg -y -i test.mp4 -ss 00:00:02.000 -map 0 -c copy %s" % os.path.join(concatDir, "test_part1.mp4"))


### PR DESCRIPTION
たとえば、
- stream 0 ビデオ
- stream 1 オーディオ
- stream 2 オーディオ

の形式になっているときに、ビデオとオーディオのストリームが1つずつしか採用されず、 stream 2 が落ちてしまっていた。